### PR TITLE
fix goreleaser conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist --snapshot
+          args: release --clean --snapshot
 
 #      - name: Upload assets for snapshots
 #        if: success() && ! startsWith(github.ref, 'refs/tags/v')
@@ -46,6 +46,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,20 +27,6 @@ jobs:
       - name: Build
         run: go build -v .
 
-      - name: Run goreleaser in snapshot mode
-        if: success() && ! startsWith(github.ref, 'refs/tags/v')
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --clean --snapshot
-
-#      - name: Upload assets for snapshots
-#        if: success() && ! startsWith(github.ref, 'refs/tags/v')
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: check_cloud_aws
-#          path: dist/*
-
       - name: Run goreleaser in release mode
         if: success() && startsWith(github.ref, 'refs/tags/v')
         uses: goreleaser/goreleaser-action@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,11 +22,11 @@ release:
     name: check_cloud_aws
 archives:
   - format: binary
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      {{- if eq .Arch "amd64" }}x86_64{{ end }}
+      {{- if eq .Os "linux" }}Linux{{ end }}
+      {{- if eq .Os "windows" }}Windows{{ end }}
+      {{- if eq .Os "darwin" }}Darwin{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
For goreleaser `--rm-dist` is deprecated. Use `--clean` instead.